### PR TITLE
Remove the usage of polymorphism

### DIFF
--- a/docs/source/auxiliar/CPP_INTRODUCTION.md
+++ b/docs/source/auxiliar/CPP_INTRODUCTION.md
@@ -40,7 +40,7 @@ int main() {
 
    auto d = reactions::make_decay<reactions::pdg_element>("pi+ -> mu+ nu_mu");
 
-   std::cout << "Decay head/number of products: " << r.head().ptr_as_element()->name() << '/' << r.products().size() << std::endl;
+   std::cout << "Decay head/number of products: " << r.head().as_element().name() << '/' << r.products().size() << std::endl;
 
    return 0;
 }

--- a/include/reactions/element_traits.hpp
+++ b/include/reactions/element_traits.hpp
@@ -5,7 +5,6 @@
 
 #include "reactions/nubase.hpp"
 #include "reactions/pdg.hpp"
-#include "reactions/pow_enum.hpp"
 
 #include <functional>
 #include <string>

--- a/include/reactions/fields.hpp
+++ b/include/reactions/fields.hpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <cmath>
 #include <optional>
-#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <type_traits>

--- a/include/reactions/nubase.hpp.in
+++ b/include/reactions/nubase.hpp.in
@@ -9,8 +9,6 @@
 #include "reactions/database.hpp"
 #include "reactions/exceptions.hpp"
 #include "reactions/fields.hpp"
-#include "reactions/pow_enum.hpp"
-#include "reactions/tokens.hpp"
 #include "reactions/units.hpp"
 #include "reactions/utils.hpp"
 

--- a/include/reactions/pdg.hpp.in
+++ b/include/reactions/pdg.hpp.in
@@ -10,7 +10,6 @@
 #include "reactions/database.hpp"
 #include "reactions/exceptions.hpp"
 #include "reactions/fields.hpp"
-#include "reactions/pow_enum.hpp"
 #include "reactions/tokens.hpp"
 #include "reactions/units.hpp"
 #include "reactions/utils.hpp"

--- a/include/reactions/processes.hpp
+++ b/include/reactions/processes.hpp
@@ -182,45 +182,21 @@ namespace reactions {
 
     /// Constructor from an element
     node(std::unique_ptr<element_type> &&ptr)
-        : m_type{std::move(processes::node_kind::element)},
-          m_ptr{ptr.release()} {}
+        : m_type{processes::node_kind::element}, m_ptr{ptr.release()} {}
 
     /// Constructor from a reaction
     node(std::unique_ptr<reaction_type> &&ptr)
-        : m_type{std::move(processes::node_kind::reaction)},
-          m_ptr{ptr.release()} {}
+        : m_type{processes::node_kind::reaction}, m_ptr{ptr.release()} {}
 
     /// Construction from a decay
     node(std::unique_ptr<decay_type> &&ptr)
-        : m_type{std::move(processes::node_kind::decay)}, m_ptr{ptr.release()} {
-    }
+        : m_type{processes::node_kind::decay}, m_ptr{ptr.release()} {}
 
     /// Move constructor
-    node(node &&other) : m_type{other.m_type}, m_ptr{other.m_ptr} {
-      other.m_ptr = nullptr;
-    }
+    node(node &&other) = default;
 
     /// Destructor
-    ~node() noexcept(false) {
-
-      if (m_ptr) {
-        switch (m_type) {
-        case (processes::node_kind::element):
-          delete ptr_as_element_wrapper();
-          return;
-        case (processes::node_kind::reaction):
-          delete ptr_as_reaction();
-          return;
-        case (processes::node_kind::decay):
-          delete ptr_as_decay();
-          return;
-        case (processes::node_kind::unknown_node_kind):
-          throw reactions::internal_error(
-              "A node type should always be set (internal error); please "
-              "report the bug");
-        }
-      }
-    }
+    ~node() = default;
 
     node() = delete;
     node(node const &) = delete;
@@ -241,7 +217,7 @@ namespace reactions {
     processes::node_kind type() const { return m_type; }
 
     /// Get the pointer to the underlying object
-    node_object const *object() const { return m_ptr; }
+    node_object const *object() const { return m_ptr.get(); }
 
     /// Return the pointer to the underlying object casted to an element
     Element const *ptr_as_element() const {
@@ -250,19 +226,19 @@ namespace reactions {
 
     /// Return the pointer to the underlying object casted to a reaction
     reaction_type const *ptr_as_reaction() const {
-      return static_cast<reaction_type *>(m_ptr);
+      return static_cast<reaction_type *>(m_ptr.get());
     }
 
     /// Return the pointer to the underlying object casted to a decay
     decay_type const *ptr_as_decay() const {
-      return static_cast<decay_type *>(m_ptr);
+      return static_cast<decay_type *>(m_ptr.get());
     }
 
   protected:
     /// Internal method to return the underlying object casted to a wrapped
     /// element
     element_type const *ptr_as_element_wrapper() const {
-      return static_cast<element_type *>(m_ptr);
+      return static_cast<element_type *>(m_ptr.get());
     }
 
   private:
@@ -270,7 +246,7 @@ namespace reactions {
     processes::node_kind m_type = processes::node_kind::unknown_node_kind;
 
     /// Underlying object
-    node_object *m_ptr = nullptr;
+    std::unique_ptr<node_object> m_ptr = nullptr;
   };
 
   /// Internal utilities for the \ref reactions::processes namespace

--- a/include/reactions/processes.hpp
+++ b/include/reactions/processes.hpp
@@ -4,7 +4,6 @@
  */
 #pragma once
 
-#include <functional>
 #include <optional>
 #include <string>
 #include <utility>

--- a/include/reactions/processes.hpp
+++ b/include/reactions/processes.hpp
@@ -26,7 +26,7 @@ namespace reactions {
    */
   namespace processes {
     /// Node types
-    REACTIONS_POW_ENUM_WITH_UNKNOWN(node_kind, element, reaction, decay);
+    REACTIONS_POW_ENUM_WITH_UNKNOWN(node_type, element, reaction, decay);
 
     /*! \brief Internal function to process an expression
      *
@@ -179,30 +179,30 @@ namespace reactions {
 
     /// Check if the underlying class is an element
     bool is_element() const {
-      return this->type() == processes::node_kind::element;
+      return this->type() == processes::node_type::element;
     }
 
     /// Check if the underlying class is a reaction
     bool is_reaction() const {
-      return type() == processes::node_kind::reaction;
+      return type() == processes::node_type::reaction;
     }
 
     /// Check if the underlying class is a decay
     bool is_decay() const {
-      return this->type() == processes::node_kind::decay;
+      return this->type() == processes::node_type::decay;
     }
 
     /// Get the node type
-    processes::node_kind type() const {
+    processes::node_type type() const {
 
       if (std::holds_alternative<element_type>(*this))
-        return processes::node_kind::element;
+        return processes::node_type::element;
       else {
         if constexpr (utils::is_template_specialization_v<chain_type, reaction>)
-          return processes::node_kind::reaction;
+          return processes::node_type::reaction;
         else if constexpr (utils::is_template_specialization_v<chain_type,
                                                                decay>)
-          return processes::node_kind::decay;
+          return processes::node_type::decay;
         else
           static_assert(utils::dependent_false_v<decltype(*this)>,
                         "Unexpected internal compile-time error");
@@ -258,19 +258,19 @@ namespace reactions {
             continue;
 
           switch (first[i].type()) {
-          case (processes::node_kind::element):
+          case (processes::node_type::element):
             if (first[i].as_element() == second[i].as_element())
               mask[j] = true;
             break;
-          case (processes::node_kind::reaction):
+          case (processes::node_type::reaction):
             if (first[i].as_chain() == second[i].as_chain())
               mask[j] = true;
             break;
-          case (processes::node_kind::decay):
+          case (processes::node_type::decay):
             if (first[i].as_chain() == second[i].as_chain())
               mask[j] = true;
             break;
-          case (processes::node_kind::unknown_node_kind):
+          case (processes::node_type::unknown_node_type):
             throw reactions::internal_error(
                 "A node can not be of unknown type (internal error); please "
                 "report the bug");

--- a/include/reactions/processes.hpp
+++ b/include/reactions/processes.hpp
@@ -5,10 +5,10 @@
 #pragma once
 
 #include <functional>
-#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "reactions/element_traits.hpp"
@@ -156,97 +156,73 @@ namespace reactions {
     }
   } // namespace processes
 
-  /*! \brief Base class for types referred to a node
-   *
-   * This base class avoids the use of void* pointers
-   */
-  struct node_object {
-    node_object() = default;
-    node_object(node_object const &) = default;
-    node_object(node_object &&) = default;
-    node_object &operator=(node_object const &) = default;
-    virtual ~node_object() = default;
-  };
+  // Forward declarations
+  template <class Element> class element_wrapper;
+  template <class Element> class reaction;
+  template <class Element> class decay;
 
   /*! \brief Base class for a process node
    *
    * This abstract class allows to check if the underlying class
-   * is an element or a composite object.
+   * is an element or a chain object.
    */
-  template <class Element> class node final {
+  template <class Element, template <class> class Chain>
+  class node final
+      : protected std::variant<element_wrapper<Element>, Chain<Element>> {
 
   public:
+    using base_type = std::variant<element_wrapper<Element>, Chain<Element>>;
     using element_type = element_wrapper<Element>;
-    using reaction_type = reaction<Element>;
-    using decay_type = decay<Element>;
+    using chain_type = Chain<Element>;
 
-    /// Constructor from an element
-    node(std::unique_ptr<element_type> &&ptr)
-        : m_type{processes::node_kind::element}, m_ptr{ptr.release()} {}
-
-    /// Constructor from a reaction
-    node(std::unique_ptr<reaction_type> &&ptr)
-        : m_type{processes::node_kind::reaction}, m_ptr{ptr.release()} {}
-
-    /// Construction from a decay
-    node(std::unique_ptr<decay_type> &&ptr)
-        : m_type{processes::node_kind::decay}, m_ptr{ptr.release()} {}
-
-    /// Move constructor
-    node(node &&other) = default;
-
-    /// Destructor
-    ~node() = default;
-
-    node() = delete;
-    node(node const &) = delete;
-    node &operator=(node const &) = delete;
+    /// Use the same constructors as \ref std::variant
+    using base_type::base_type;
 
     /// Check if the underlying class is an element
-    bool is_element() const { return m_type == processes::node_kind::element; }
+    bool is_element() const {
+      return this->type() == processes::node_kind::element;
+    }
 
     /// Check if the underlying class is a reaction
     bool is_reaction() const {
-      return m_type == processes::node_kind::reaction;
+      return type() == processes::node_kind::reaction;
     }
 
     /// Check if the underlying class is a decay
-    bool is_decay() const { return m_type == processes::node_kind::decay; }
+    bool is_decay() const {
+      return this->type() == processes::node_kind::decay;
+    }
 
     /// Get the node type
-    processes::node_kind type() const { return m_type; }
+    processes::node_kind type() const {
 
-    /// Get the pointer to the underlying object
-    node_object const *object() const { return m_ptr.get(); }
+      if (std::holds_alternative<element_type>(*this))
+        return processes::node_kind::element;
+      else {
+        if constexpr (utils::is_template_specialization_v<chain_type, reaction>)
+          return processes::node_kind::reaction;
+        else if constexpr (utils::is_template_specialization_v<chain_type,
+                                                               decay>)
+          return processes::node_kind::decay;
+        else
+          static_assert(utils::dependent_false_v<decltype(*this)>,
+                        "Unexpected internal compile-time error");
+      }
+    }
 
     /// Return the pointer to the underlying object casted to an element
-    Element const *ptr_as_element() const {
-      return ptr_as_element_wrapper()->operator->();
-    }
+    Element const &as_element() const { return *as_element_wrapper(); }
 
     /// Return the pointer to the underlying object casted to a reaction
-    reaction_type const *ptr_as_reaction() const {
-      return static_cast<reaction_type *>(m_ptr.get());
-    }
-
-    /// Return the pointer to the underlying object casted to a decay
-    decay_type const *ptr_as_decay() const {
-      return static_cast<decay_type *>(m_ptr.get());
+    chain_type const &as_chain() const {
+      return std::get<Chain<Element>>(*this);
     }
 
   protected:
-    /// Internal method to return the underlying object casted to a wrapped
-    /// element
-    element_type const *ptr_as_element_wrapper() const {
-      return static_cast<element_type *>(m_ptr.get());
+    /// Return the underlying object casted to a wrapped
+    element_type const &as_element_wrapper() const {
+      return std::get<element_type>(*this);
     }
-
-  private:
-    /// Node type
-    processes::node_kind m_type = processes::node_kind::unknown_node_kind;
-
-    /// Underlying object
-    std::unique_ptr<node_object> m_ptr = nullptr;
   };
 
   /// Internal utilities for the \ref reactions::processes namespace
@@ -258,9 +234,9 @@ namespace reactions {
      * \return whether the two nodes are equal or not (processing
      * whether they are reactions, decays or elements).
      */
-    template <class Element>
-    inline bool check_nodes(std::vector<node<Element>> const &first,
-                            std::vector<node<Element>> const &second) {
+    template <class Element, template <class> class Chain>
+    inline bool check_nodes(std::vector<node<Element, Chain>> const &first,
+                            std::vector<node<Element, Chain>> const &second) {
 
       auto size = first.size();
 
@@ -284,15 +260,15 @@ namespace reactions {
 
           switch (first[i].type()) {
           case (processes::node_kind::element):
-            if (*(first[i].ptr_as_element()) == *(second[i].ptr_as_element()))
+            if (first[i].as_element() == second[i].as_element())
               mask[j] = true;
             break;
           case (processes::node_kind::reaction):
-            if (*(first[i].ptr_as_reaction()) == *(second[i].ptr_as_reaction()))
+            if (first[i].as_chain() == second[i].as_chain())
               mask[j] = true;
             break;
           case (processes::node_kind::decay):
-            if (*(first[i].ptr_as_decay()) == *(second[i].ptr_as_decay()))
+            if (first[i].as_chain() == second[i].as_chain())
               mask[j] = true;
             break;
           case (processes::node_kind::unknown_node_kind):
@@ -319,13 +295,13 @@ namespace reactions {
    * This class wraps the template argument type, which becomes accessible
    * through the * and -> operators.
    */
-  template <class Element> class element_wrapper final : public node_object {
+  template <class Element> class element_wrapper final {
 
   public:
     /// Constructor given the underlying element
-    element_wrapper(Element &&e) : node_object{}, m_element{std::move(e)} {}
+    element_wrapper(Element &&e) : m_element{std::move(e)} {}
     /// Default destructor
-    ~element_wrapper() override = default;
+    ~element_wrapper() = default;
     /// Copy constructor
     element_wrapper(const element_wrapper &) = default;
     /// Move constructor
@@ -348,14 +324,15 @@ namespace reactions {
    *
    * Nested reactions must be expressed within parenteses.
    */
-  template <class Element> class reaction final : public node_object {
+  template <class Element> class reaction final {
 
   public:
     using element_type = element_wrapper<Element>; /// Underlying element type
     using builder_type =
         element_traits::builder_tpl_t<Element>; /// Signature type of an element
                                                 /// builder
-    using nodes_type = std::vector<node<Element>>; /// Collection of elements
+    using nodes_type =
+        std::vector<node<Element, reaction>>; /// Collection of elements
 
     /// Default move constructor
     reaction(reaction &&) = default;
@@ -408,12 +385,6 @@ namespace reactions {
              std::string::const_iterator const &end, builder_type builder)
         : reaction{begin, end, builder} {}
 
-    // Create a new instance using the protected constructor
-    friend std::unique_ptr<reaction>
-    std::make_unique<reaction>(std::string::const_iterator &,
-                               std::string::const_iterator const &,
-                               builder_type);
-
     template <class Process>
     friend Process
     reactions::processes::make_process(std::string const &,
@@ -430,18 +401,16 @@ namespace reactions {
      * a string.
      */
     reaction(std::string::const_iterator &sit,
-             std::string::const_iterator const &end, builder_type builder)
-        : node_object{} {
+             std::string::const_iterator const &end, builder_type builder) {
 
       nodes_type *current_set = &m_reactants;
 
       auto fill_element =
           [&](std::string::const_iterator const &start) -> void {
-        current_set->push_back(
-            std::make_unique<element_type>(builder(std::string{start, sit})));
+        current_set->emplace_back(builder(std::string{start, sit}));
       };
       auto fill_reaction = [&]() -> void {
-        current_set->push_back(std::make_unique<reaction>(sit, end, builder));
+        current_set->emplace_back(reaction(sit, end, builder));
       };
       auto arrow_switch = [&]() -> void {
         if (!m_reactants.size())
@@ -477,14 +446,14 @@ namespace reactions {
    * products
    *
    * This can be seen as a special reaction with only one reactant, and where
-   * subsequent composite nodes are also decays.
+   * subsequent chain nodes are also decays.
    */
-  template <class Element> class decay final : public node_object {
+  template <class Element> class decay final {
 
   public:
     using element_type = element_wrapper<Element>;
     using builder_type = element_traits::builder_tpl_t<Element>;
-    using nodes_type = std::vector<node<Element>>;
+    using nodes_type = std::vector<node<Element, decay>>;
 
     /// Default move constructor
     decay(decay &&) = default;
@@ -533,11 +502,6 @@ namespace reactions {
           std::string::const_iterator const &end, builder_type builder)
         : decay{begin, end, builder} {}
 
-    /// Create a new instance using the protected constructor
-    friend std::unique_ptr<decay>
-    std::make_unique<decay>(std::string::const_iterator &,
-                            std::string::const_iterator const &, builder_type);
-
     template <class Process>
     friend Process
     reactions::processes::make_process(std::string const &,
@@ -554,8 +518,7 @@ namespace reactions {
      * a string.
      */
     decay(std::string::const_iterator &sit,
-          std::string::const_iterator const &end, builder_type builder)
-        : node_object{} {
+          std::string::const_iterator const &end, builder_type builder) {
 
       bool fill_products = false; // keep track of the elements we are adding
 
@@ -564,8 +527,7 @@ namespace reactions {
         if (!m_head) {
           this->m_head.emplace(builder(std::string{start, sit}));
         } else if (fill_products) {
-          this->m_products.emplace_back(
-              std::make_unique<element_type>(builder(std::string{start, sit})));
+          this->m_products.emplace_back(builder(std::string{start, sit}));
         } else
           throw reactions::exceptions::__syntax_error("Missing arrow",
                                                       end - start);
@@ -575,8 +537,7 @@ namespace reactions {
           throw reactions::exceptions::__syntax_error("Missing head",
                                                       end - sit);
         } else if (fill_products) {
-          this->m_products.push_back(
-              std::make_unique<decay>(sit, end, builder));
+          this->m_products.emplace_back(decay(sit, end, builder));
         } else
           throw reactions::exceptions::__syntax_error("Missing arrow",
                                                       end - sit);

--- a/include/reactions/units.hpp
+++ b/include/reactions/units.hpp
@@ -2,9 +2,10 @@
 \brief Definition of units
  */
 #pragma once
-#include "reactions/database.hpp"
 #include "reactions/exceptions.hpp"
 #include "reactions/pow_enum.hpp"
+#include <string>
+#include <type_traits>
 
 namespace reactions {
 

--- a/python/src/capi.cpp
+++ b/python/src/capi.cpp
@@ -1,7 +1,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
-#include "composites.hpp"
+#include "chains.hpp"
 #include "database.hpp"
 #include "element_nubase.hpp"
 #include "element_pdg.hpp"

--- a/python/src/capi.cpp
+++ b/python/src/capi.cpp
@@ -41,7 +41,7 @@ PyObject *node_type(PyObject *module, PyObject *args) {
   REACTIONS_PYTHON_NODE_CHECK_UNKNOWN(((Node *)obj));
 
   return PyUnicode_FromString(
-      reactions::processes::node_kind_properties::to_c_string(
+      reactions::processes::node_type_properties::to_c_string(
           ((Node *)obj)->c_type));
 }
 

--- a/python/src/chains.hpp
+++ b/python/src/chains.hpp
@@ -185,7 +185,7 @@ static PyObject *Reaction_new(PyTypeObject *type, PyObject *Py_UNUSED(args),
     return NULL;
 
   // Set the type for the base class
-  self->node.c_type = reactions::processes::node_kind::reaction;
+  self->node.c_type = reactions::processes::node_type::reaction;
 
   return (PyObject *)self;
 }
@@ -466,7 +466,7 @@ static PyObject *Decay_new(PyTypeObject *type, PyObject *Py_UNUSED(args),
     return NULL;
 
   // Set the type for the base class
-  self->node.c_type = reactions::processes::node_kind::decay;
+  self->node.c_type = reactions::processes::node_type::decay;
 
   return (PyObject *)self;
 }

--- a/python/src/chains.hpp
+++ b/python/src/chains.hpp
@@ -3,7 +3,6 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
-#include "reactions/element_traits.hpp"
 #include "reactions/nubase.hpp"
 #include "reactions/pdg.hpp"
 

--- a/python/src/chains.hpp
+++ b/python/src/chains.hpp
@@ -316,10 +316,9 @@ python_node_fill_reaction(Reaction *self,
 
     auto &obj = reac.reactants().at(i);
 
-    PyObject *o =
-        obj.is_element()
-            ? python_element<Element>::new_instance(*(obj.ptr_as_element()))
-            : Reaction_New(*(obj.ptr_as_reaction()));
+    PyObject *o = obj.is_element()
+                      ? python_element<Element>::new_instance(obj.as_element())
+                      : Reaction_New(obj.as_chain());
 
     if (!o) {
       PyErr_SetString(InternalError, "Unable to create element");
@@ -334,10 +333,9 @@ python_node_fill_reaction(Reaction *self,
 
     auto &obj = reac.products().at(i);
 
-    PyObject *o =
-        obj.is_element()
-            ? python_element<Element>::new_instance(*(obj.ptr_as_element()))
-            : Reaction_New(*(obj.ptr_as_reaction()));
+    PyObject *o = obj.is_element()
+                      ? python_element<Element>::new_instance(obj.as_element())
+                      : Reaction_New(obj.as_chain());
 
     if (!o) {
       PyErr_SetString(InternalError, "Unable to create element");
@@ -622,10 +620,9 @@ inline bool python_node_fill_decay(Decay *self,
 
     auto &obj = reac.products().at(i);
 
-    PyObject *o =
-        obj.is_element()
-            ? python_element<Element>::new_instance(*(obj.ptr_as_element()))
-            : Decay_New(*(obj.ptr_as_decay()));
+    PyObject *o = obj.is_element()
+                      ? python_element<Element>::new_instance(obj.as_element())
+                      : Decay_New(obj.as_chain());
 
     if (!o) {
       PyErr_SetString(InternalError, "Unable to create decay");

--- a/python/src/database.hpp
+++ b/python/src/database.hpp
@@ -1,15 +1,15 @@
 #pragma once
+#include <utility>
+
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
-#include "reactions/exceptions.hpp"
 #include "reactions/nubase.hpp"
 #include "reactions/pdg.hpp"
 
 #include "element_nubase.hpp"
 #include "element_pdg.hpp"
 #include "errors.hpp"
-#include "utils.hpp"
 
 #define REACTIONS_PYTHON_CHECK_DATABASE(database)                              \
   if (!database) {                                                             \
@@ -21,12 +21,12 @@
 
 /// Create a new PDG element
 static PyObject *element_new(reactions::pdg_element &&el) {
-  return ElementPDG_New(el);
+  return ElementPDG_New(std::forward<reactions::pdg_element>(el));
 }
 
 /// Create a new NuBase element
 static PyObject *element_new(reactions::nubase_element &&el) {
-  return ElementNuBase_New(el);
+  return ElementNuBase_New(std::forward<reactions::nubase_element>(el));
 }
 
 /// General methods to a database

--- a/python/src/element.hpp
+++ b/python/src/element.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include "reactions/pdg.hpp"
 #include "reactions/pow_enum.hpp"
 
 #include "element_nubase.hpp"

--- a/python/src/element_nubase.hpp
+++ b/python/src/element_nubase.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <string>
 #include <tuple>
+#include <utility>
 
 #include "reactions/fields.hpp"
 #include "reactions/nubase.hpp"

--- a/python/src/element_nubase.hpp
+++ b/python/src/element_nubase.hpp
@@ -29,7 +29,7 @@ static PyObject *ElementNuBase_new(PyTypeObject *type,
     return NULL;
 
   // Set the type for the base class
-  self->node.c_type = reactions::processes::node_kind::element;
+  self->node.c_type = reactions::processes::node_type::element;
 
   return (PyObject *)self;
 }

--- a/python/src/element_pdg.hpp
+++ b/python/src/element_pdg.hpp
@@ -28,7 +28,7 @@ static PyObject *ElementPDG_new(PyTypeObject *type, PyObject *Py_UNUSED(args),
     return NULL;
 
   // Set the type for the base class
-  self->node.c_type = reactions::processes::node_kind::element;
+  self->node.c_type = reactions::processes::node_type::element;
 
   return (PyObject *)self;
 }

--- a/python/src/element_pdg.hpp
+++ b/python/src/element_pdg.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <string>
 #include <tuple>
+#include <utility>
 
 #include "reactions/fields.hpp"
 #include "reactions/pdg.hpp"

--- a/python/src/element_string.hpp
+++ b/python/src/element_string.hpp
@@ -23,7 +23,7 @@ static PyObject *ElementString_new(PyTypeObject *type,
     return NULL;
 
   // Set the type for the base class
-  self->node.c_type = reactions::processes::node_kind::element;
+  self->node.c_type = reactions::processes::node_type::element;
 
   return (PyObject *)self;
 }

--- a/python/src/node.hpp
+++ b/python/src/node.hpp
@@ -7,12 +7,12 @@
 
 // Wrapper for a node
 typedef struct {
-  PyObject_HEAD reactions::processes::node_kind c_type =
-      reactions::processes::node_kind::unknown_node_kind;
+  PyObject_HEAD reactions::processes::node_type c_type =
+      reactions::processes::node_type::unknown_node_type;
 } Node;
 
 #define REACTIONS_PYTHON_NODE_CHECK_UNKNOWN(self)                              \
-  if (self->c_type == reactions::processes::node_kind::unknown_node_kind) {    \
+  if (self->c_type == reactions::processes::node_type::unknown_node_type) {    \
     PyErr_SetString(InternalError,                                             \
                     "Node type is not defined; please report the bug");        \
     return NULL;                                                               \
@@ -33,7 +33,7 @@ static PyObject *Node_new(PyTypeObject *type, PyObject *args,
   if (!self)
     return NULL;
 
-  self->c_type = reactions::processes::node_kind::unknown_node_kind;
+  self->c_type = reactions::processes::node_type::unknown_node_type;
 
   return (PyObject *)self;
 }

--- a/python/src/system_of_units.hpp
+++ b/python/src/system_of_units.hpp
@@ -5,8 +5,7 @@
 
 #include "reactions/nubase.hpp"
 #include "reactions/pdg.hpp"
-
-#include "utils.hpp"
+#include "reactions/units.hpp"
 
 /// Accessor to energy units
 template <class SystemOfUnits> struct energy_units_accessor {

--- a/python/src/utils.hpp
+++ b/python/src/utils.hpp
@@ -1,9 +1,9 @@
 #pragma once
-#include <optional>
 #include <sstream>
 #include <string>
+#include <type_traits>
 
-#include "reactions/database.hpp"
+#include "reactions/fields.hpp"
 
 #define REACTIONS_INSTANCE_ACCESSOR "__instance"
 

--- a/repository
+++ b/repository
@@ -12,6 +12,7 @@ Main arguments:
 -b|--build-cpp: build the project under a "build" directory. It can be used together with "--clean".
 -p|--build-python: build the python package in development mode (assumes to be within a virtual environment)
 -d|--build-docs: build the documentation (inside docs/build)
+-t|--format: apply the format
 -c|--clean: clean the repository of temporary files, caches, build directories, ...
 -f|--force: when specified before any number of commands described above, forces their execution, without any further interaction with the user
 
@@ -42,6 +43,19 @@ while [[ $# -gt 0 ]]; do
 	    fi
 	    shift
 	    ;;
+	-t|--format)
+
+	    echo "Formatting files"
+	    python setup.py apply_format --regex '(docs|python|include|test|scripts)'
+	    if [ $? -eq 0 ]; then
+		echo "Successfully formatted files"
+	    else
+		echo "ERROR: Failed to format files"
+		exit 1
+	    fi
+	    shift
+	    ;;
+
 	-c|--clean)
 
 	    echo "Running \"make clean\" in the documentation directory"


### PR DESCRIPTION
Stop using `std::unique_ptr` to refer to nodes and remove the polymorphism of the `element_wrapper`, `decay` and `reaction` classes. Use `std::variant` objects to refer to nodes. Remove useless headers.