### PR TITLE
Fix the build in ReadTheDocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ jobs:
     - export LATEST_TAG=$(git describe --tags $(git rev-list --exclude=${EXCLUDE_PATTERN} --tags --max-count=1))
     - if [[ -z ${NEW_TAG} || -z ${LATEST_TAG} ]]; then exit 1; fi
     # Change the name of the tag if we are not in master
-    - if [ ${TRAVIS_BRANCH} != master ]; then export TRAVIS_TAG=devel-${TRAVIS_TAG}; else export TRAVIS_TAG=${NEW_TAG}; fi
+    - if [ ${TRAVIS_BRANCH} != master ]; then export TRAVIS_TAG=devel-${NEW_TAG}; else export TRAVIS_TAG=${NEW_TAG}; fi
     # Install Ruby and github_changelog_generator
     - sudo apt-get update
     - sudo apt-get install -y ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,19 +70,20 @@ jobs:
     # Export the path to the package
     - export PYTHONPATH=${PYTHONPATH}:python
     # Define the new and previous tags
-    - export TRAVIS_TAG=v$(python -c "import reactions; print(reactions.__version__)")
-    - if [[ ! ${TRAVIS_TAG} =~ "dev" ]]; then export EXCLUDE_PATTERN='*dev*'; fi
+    - export NEW_TAG=v$(python -c "import reactions; print(reactions.__version__)")
+    - if [[ ! ${NEW_TAG} =~ "dev" ]]; then export EXCLUDE_PATTERN='*dev*'; fi
     - export LATEST_TAG=$(git describe --tags $(git rev-list --exclude=${EXCLUDE_PATTERN} --tags --max-count=1))
-    - if [[ -z ${TRAVIS_TAG} || -z ${LATEST_TAG} ]]; then exit 1; fi
+    - if [[ -z ${NEW_TAG} || -z ${LATEST_TAG} ]]; then exit 1; fi
     # Change the name of the tag if we are not in master
-    - if [ ${TRAVIS_BRANCH} != master ]; then export TRAVIS_TAG=devel-${TRAVIS_TAG}; fi
+    - if [ ${TRAVIS_BRANCH} != master ]; then export TRAVIS_TAG=devel-${TRAVIS_TAG}; else export TRAVIS_TAG=${NEW_TAG}; fi
     # Install Ruby and github_changelog_generator
     - sudo apt-get update
     - sudo apt-get install -y ruby
     - ruby --version
     - gem install github_changelog_generator
     # Generate the changelog file
-    - ./repository changelog -o ${TRAVIS_TAG}-changelog.md --since-tag ${LATEST_TAG} --future-release ${TRAVIS_TAG} -t ${GITHUB_TOKEN}
+    - ./repository changelog -o ${NEW_TAG}-changelog.md --since-tag ${LATEST_TAG} --future-release ${NEW_TAG} -t ${GITHUB_TOKEN}
+    - ./repository changelog -o ${NEW_TAG}-full-changelog.md --since-tag v0.0.0 --future-release ${NEW_TAG} -t ${GITHUB_TOKEN}
     before_install: " "
     install: " "
     script: " "
@@ -91,7 +92,9 @@ jobs:
         token: ${GITHUB_TOKEN}
         tag_name: ${TRAVIS_TAG}
         name: ${TRAVIS_TAG}
-        file: ${TRAVIS_TAG}-changelog.md
+        file:
+        - ${NEW_TAG}-changelog.md
+        - ${NEW_TAG}-full-changelog.md
         skip_cleanup: true
         draft: true
         on:

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS       =
-SPHINXBUILD      = python -msphinx
+SPHINXBUILD      = IS_LOCAL_BUILD=true python -msphinx
 SPHINXPROJ       = reactions
 SOURCEDIR        = source
 BUILDDIR        := $(if $(BUILDDIR),$(BUILDDIR),./build)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,8 +66,8 @@ OUTPUT_DIRECTORY = {cpp_doc_dir}
 
     os.makedirs(auxiliar_tmp_dir, exist_ok=True)
 
+    tmp_changelog = os.path.join(tmpdir, 'changelog.md')
     if os.environ.get('IS_LOCAL_BUILD', False):
-        tmp_changelog = os.path.join(tmpdir, 'changelog.md')
         subprocess.check_call(['bash', 'repository', 'changelog', '-o', tmp_changelog,
                                '--include-tags-regex', '^v[0-9]*\.[0-9]*\.[0-9]$', '--since-tag', 'v0.0.0'], cwd=root)
     else:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,6 @@ import shutil
 import subprocess
 import sys
 import tempfile
-import time
 import warnings
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,7 @@ OUTPUT_DIRECTORY = {cpp_doc_dir}
     else:
         if subprocess.call(['wget', f'https://github.com/mramospe/reactions/archive/refs/tags/v{reactions.__version__}-full-changelog.md', '-O', tmp_changelog]) != 0:
             warnings.warn(
-                RuntimeWarning, 'Unable to find full changelog; setting it to an empty file')
+                'Unable to find full changelog; setting it to an empty file', RuntimeWarning)
 
     subprocess.check_call(['pandoc', tmp_changelog, '-o',
                            os.path.join(auxiliar_tmp_dir, 'changelog.rst')])


### PR DESCRIPTION
Fix the build process of the documentation in ReadTheDocs by using the changelog deployed by Travis. If the deployment has not finished yet the file is empty and a warning is displayed.