### PR TITLE
Improve the build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,4 @@ reactions.egg-info/
 __pycache__
 *.so
 docs/build
-/include/reactions/nubase.hpp
-/include/reactions/pdg.hpp
 .coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
     script: pytest
     after_success: if [[ ${TRAVIS_PULL_REQUEST} != "false" ]]; then codecov; fi
   - name: deploy
-    if: branch = devel || branch = master
+    if: branch IN (master, devel)
     python: 3.7
     before_deploy:
     # Define the Git configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,12 @@ file(GLOB_RECURSE HEADER_FILES_TO_CONFIG ${PROJECT_SOURCE_DIR}/include/reactions
 install(FILES ${HEADER_FILES} DESTINATION include/reactions)
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/python/reactions/data DESTINATION ${PROJECT_BINARY_DIR})
+
 set(PDG_TABLE ${PROJECT_BINARY_DIR}/data/pdg_mass_width_2020.txt)
 set(NUBASE_TABLE ${PROJECT_BINARY_DIR}/data/nubase_2020.txt)
 foreach(include_file ${HEADER_FILES_TO_CONFIG})
   string(REPLACE ".in" "" file_name ${include_file})
+  string(REPLACE ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR} file_name ${file_name})
   configure_file(${include_file} ${file_name})
 endforeach()
 
@@ -57,7 +59,7 @@ install(FILES ${HEADER_FILES} DESTINATION ${PROJECT_BINARY_DIR}/include/reaction
 #
 if(INSTALL_TESTS)
     file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/test)
-    include_directories(include test/cpp)
+    include_directories(${PROJECT_BINARY_DIR}/include include test/cpp)
     file(GLOB TEST_SOURCES ${PROJECT_SOURCE_DIR}/test/cpp/*.cpp)
     set(CMAKE_CXX_FLAGS "-O3 -pedantic -Wall -Wextra")
     set(CMAKE_CXX_FLAGS_DEBUG "-g -pedantic -Wall -Wextra")

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Elements involved in these processes can be customized given a user-defined clas
 A bulitin implementation of the [PDG](https://pdg.lbl.gov) database of particles and the
 [NuBase](http://amdc.in2p3.fr/web/nubase_en.html) database of nuclei is included.
 
-The Reactions package allows to define a work with trees of processes among different
+The Reactions package allows to define and work with trees of processes among different
 elements.
 These processes can be either a reaction, where one or more reactants generate a set
 of products; or a decay, where a single element generates a set of products.

--- a/setup.py
+++ b/setup.py
@@ -144,46 +144,6 @@ class ApplyFormatCommand(DirectoryWorker):
                 raise RuntimeError('Problems found while formatting C files')
 
 
-class ApplyCopyrightCommand(DirectoryWorker):
-
-    description = 'add the copyright to the files in the directories'
-
-    def _check_add_copyright(self, path, preamble):
-        """
-        Check that the given file has the provided copyright and add it in case
-        it is not present.
-        """
-        with open(path) as f:
-            data = f.read()
-
-        if not preamble in data:
-
-            if data.startswith('#!'):  # is a script
-                lines = data.splitlines(keepends=True)
-                text = f'{lines[0]}{preamble}{"".join(lines[1:])}'
-            else:
-                text = f'{preamble}{data}'
-
-            with open(path, 'wt') as f:
-                f.write(text)
-
-    def run(self):
-        """
-        Execution of the command action.
-        """
-        for directory in self.directories:
-            python_files = python_files_in(directory)
-            c_files = cpp_files_in(directory)
-
-            lic = license_for_language('python')
-            for pf in python_files:
-                self._check_add_copyright(pf, lic)
-
-            lic = license_for_language('cpp')
-            for cf in c_files:
-                self._check_add_copyright(cf, lic)
-
-
 class CheckFormatCommand(DirectoryWorker):
 
     description = 'check the format of the files of a certain type in a given directory'


### PR DESCRIPTION
Some unused code has been removed and the files to configure `*.hpp.in` are now modified and placed in the binary directory (and not in the source directory) during the installation.