### PR TITLE
Improve documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: xenial
 language: python
 
-if: (branch IN (master, devel)) OR (head_branch IN (master, devel))
-
 os: linux
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 dist: xenial
 language: python
 
+if: (branch IN (master, devel)) OR (head_branch IN (master, devel))
+
 os: linux
 addons:
   apt:

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -292,7 +292,7 @@ OPTIMIZE_OUTPUT_VHDL   = NO
 # Note that for custom extensions you also need to set FILE_PATTERNS otherwise
 # the files are not read by doxygen.
 
-EXTENSION_MAPPING      =
+EXTENSION_MAPPING      = in=C++
 
 # If the MARKDOWN_SUPPORT tag is enabled then doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
@@ -816,50 +816,7 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
-FILE_PATTERNS          = *.c \
-                         *.cc \
-                         *.cxx \
-                         *.cpp \
-                         *.c++ \
-                         *.java \
-                         *.ii \
-                         *.ixx \
-                         *.ipp \
-                         *.i++ \
-                         *.inl \
-                         *.idl \
-                         *.ddl \
-                         *.odl \
-                         *.h \
-                         *.hh \
-                         *.hxx \
-                         *.hpp \
-                         *.h++ \
-                         *.cs \
-                         *.d \
-                         *.php \
-                         *.php4 \
-                         *.php5 \
-                         *.phtml \
-                         *.inc \
-                         *.m \
-                         *.markdown \
-                         *.md \
-                         *.mm \
-                         *.dox \
-                         *.py \
-                         *.pyw \
-                         *.f90 \
-                         *.f95 \
-                         *.f03 \
-                         *.f08 \
-                         *.f \
-                         *.for \
-                         *.tcl \
-                         *.vhd \
-                         *.vhdl \
-                         *.ucf \
-                         *.qsf
+FILE_PATTERNS          = *.hpp *.in *.cpp
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -2075,7 +2032,7 @@ EXPAND_ONLY_PREDEF     = NO
 # The default value is: YES.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-SEARCH_INCLUDES        = YES
+SEARCH_INCLUDES        = NO
 
 # The INCLUDE_PATH tag can be used to specify one or more directories that
 # contain include files that are not input files but should be processed by the

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -57,4 +57,4 @@ html: html-doc;
 latexpdf: latexpdf-doc;
 
 clean:
-	@rm -rf source/_static/cpp source/api build
+	@rm -rf source/_static/cpp source/_static/*.pdf source/api build

--- a/include/reactions/database.hpp
+++ b/include/reactions/database.hpp
@@ -11,6 +11,7 @@
 #include "reactions/exceptions.hpp"
 #include "reactions/fields.hpp"
 
+/// Common tools and base objects to handle databases
 namespace reactions::database {
 
   /*! \brief Base database class

--- a/include/reactions/database.hpp
+++ b/include/reactions/database.hpp
@@ -1,5 +1,5 @@
 /*! \file
- * \brief Define the base database class
+  \brief Define the base database class
  */
 #pragma once
 #include <fstream>

--- a/include/reactions/fields.hpp
+++ b/include/reactions/fields.hpp
@@ -38,7 +38,7 @@ namespace reactions {
   - **value_type**: a type representing the object that is stored (can be a
   \ref std::optional).
 
-  - **units_reference_type**: a resolved type of the \ref fields::reference
+  - **units_reference_type**: a resolved type of the \ref units::reference
   template, containing the units of the field and the associated units in the
   database. If the field has no units, \ref units::none must be used.
 
@@ -50,7 +50,7 @@ namespace reactions {
   (*Subfield*) that identifies the member.
 
   The access to a value of a field (or a member of a field) is handled by
-  \ref fields::accessor, which automatically handles the system of units
+  \ref units::accessor, which automatically handles the system of units
   and the access to members of a field. If at some point the associated
   type is a \ref std::optional, the value is accessed without checking its
   validity.
@@ -339,9 +339,9 @@ namespace reactions::fields {
   /// Accessor to a value/error field
   template <class Field> static constexpr get_t<Field> get;
 
-  /// Optional for \ref float type
+  /// Optional for floating point type
   using float_opt = std::optional<float>;
-  /// Optional for \ref double type
+  /// Optional for double floating point type
   using double_opt = std::optional<double>;
   /// Optional \ref value_and_error for single-precision floating-point type
   using ve_float_opt = std::optional<value_and_error<float>>;

--- a/include/reactions/nubase.hpp.in
+++ b/include/reactions/nubase.hpp.in
@@ -14,8 +14,9 @@
 
 namespace reactions {
 
-  /// Structures representing the fields of a \ref reactions::nubase_element
-  /// object
+  /*! \brief Structures representing the fields of a \ref
+   * reactions::nubase_element object
+   */
   namespace nubase {
 
     /// Range of a variable in a file

--- a/include/reactions/pdg.hpp.in
+++ b/include/reactions/pdg.hpp.in
@@ -16,7 +16,9 @@
 
 namespace reactions {
 
-  /// Structures representing the fields of a \ref reactions::pdg_element object
+  /*! \brief Structures representing the fields of a \ref reactions::pdg_element
+   * object
+   */
   namespace pdg {
 
     /// Range of a variable in a file

--- a/include/reactions/processes.hpp
+++ b/include/reactions/processes.hpp
@@ -394,7 +394,7 @@ namespace reactions {
      * This constructor is called internally when creating reactions that
      * contain other reactions.
      *
-     * \param begin iterator pointing to the beginning of the string.
+     * \param sit iterator pointing to the current read position in the string.
      * \param end iterator pointing to the end of the string.
      * \param builder function to create the underlying element from
      * a string.

--- a/include/reactions/units.hpp
+++ b/include/reactions/units.hpp
@@ -217,7 +217,7 @@ namespace reactions {
     /// \copydoc accessor_t
     template <class Field, class Subfield, class... S>
     struct accessor_t<Field, Subfield, S...> {
-      /// \copydoc accessor_t::operator()
+      /// Access the value of the subfield and process the units
       template <class T>
       constexpr fields::field_member_type_t<Field, Subfield, S...> const &
       operator()(T const &f) const {

--- a/include/reactions/units.hpp
+++ b/include/reactions/units.hpp
@@ -1,5 +1,5 @@
-/* \file
-\brief Definition of units
+/*! \file
+  \brief Definition of units
  */
 #pragma once
 #include "reactions/exceptions.hpp"

--- a/include/reactions/utils.hpp
+++ b/include/reactions/utils.hpp
@@ -1,3 +1,6 @@
+/*! \file
+  \brief Functions and structs to handle templated types.
+*/
 #pragma once
 #include <tuple>
 


### PR DESCRIPTION
Include some fixes to the documentation:

* Explicitly define the file extensions to consider as C++ header files (fix issue with files to configure `*.in`)
* Add missing documentation to some files and namespaces
* Allow to do a lazy build of the documentations, skipping the generation of element tables and the changelog